### PR TITLE
Fixes attribute generator crash (#19)

### DIFF
--- a/src/core/attrsgenerator.cpp
+++ b/src/core/attrsgenerator.cpp
@@ -43,22 +43,22 @@ AttrsGeneratorPtr AttrsGenerator::parse(const AttributesScope& attrsScope,
         _cmd = QString("*%1;min").arg(size);
         cmds.push_back(cmd);
         cmds.push_back("min");
-    } else if (cmd.indexOf(";") != -1){
-        cmds = cmd.split(";");
+    } else {
+        _cmd = cmd;
+        if (cmd.indexOf(";") != -1){            
+            cmds = _cmd.split(";");
+        } else {
+            cmds << _cmd;
+        }
         QString sizeStr = cmds.first();
         size = sizeStr.remove(0,1).toInt(&sizeIsValid);
         _cmd = cmd;
-    } else { // if cmd isn't an integer or semicolon seperated, throw an error
-        error = "the command '" + cmd + "' is invalid!";
-        qWarning() << error;
-        return nullptr;
     }
-
+    
     if (sizeIsValid) {
         if (size < 1) {
             error = "Unable to parse '" + cmd + "'.\n"
                     "The size of the attributes set cannot be negative!";
-            qWarning() << error;
             return nullptr;
         }
         // the size was parsed correctly, let's take it out of the cmds

--- a/src/core/attrsgenerator.cpp
+++ b/src/core/attrsgenerator.cpp
@@ -54,11 +54,11 @@ AttrsGeneratorPtr AttrsGenerator::parse(const AttributesScope& attrsScope,
         size = sizeStr.remove(0,1).toInt(&sizeIsValid);
         _cmd = cmd;
     }
-    
     if (sizeIsValid) {
         if (size < 1) {
             error = "Unable to parse '" + cmd + "'.\n"
                     "The size of the attributes set cannot be negative!";
+            qWarning() << error;
             return nullptr;
         }
         // the size was parsed correctly, let's take it out of the cmds

--- a/src/core/attrsgenerator.cpp
+++ b/src/core/attrsgenerator.cpp
@@ -41,12 +41,17 @@ AttrsGeneratorPtr AttrsGenerator::parse(const AttributesScope& attrsScope,
     int size = cmd.toInt(&sizeIsValid);
     if (sizeIsValid) { // cmd is just an interger
         _cmd = QString("*%1;min").arg(size);
+        cmds.push_back(cmd);
         cmds.push_back("min");
-    } else {
+    } else if (cmd.indexOf(";") != -1){
         cmds = cmd.split(";");
         QString sizeStr = cmds.first();
         size = sizeStr.remove(0,1).toInt(&sizeIsValid);
         _cmd = cmd;
+    } else { // if cmd isn't an integer or semicolon seperated, throw an error
+        error = "the command '" + cmd + "' is invalid!";
+        qWarning() << error;
+        return nullptr;
     }
 
     if (sizeIsValid) {

--- a/src/test/tst_attrsgenerator.cpp
+++ b/src/test/tst_attrsgenerator.cpp
@@ -34,6 +34,7 @@ private slots:
     void cleanupTestCase() {}
     void tst_parseStarCmd();
     void tst_parseHashCmd();
+    void tst_parseIntegerCmd();
 
 private:
     void _tst_attrs(const SetOfAttributes& res,
@@ -169,6 +170,22 @@ void TestAttrsGenerator::_tst_parseStarCmd(const QString& func, const Attributes
             _tst_attrs(res, attrs, false);
         }
     }
+}
+
+void TestAttrsGenerator::tst_parseIntegerCmd()
+{
+    const QStringList attrRgeStrs = {"int[0,16]"};
+    const QStringList names = {"test0"};
+    
+    QString error;
+    QString _cmd = "8";
+    QString _exp_cmd = "*8;min";
+    const QString def_func = "min";
+
+    const AttributesScope attrsScope = _newAttrsScope(names, attrRgeStrs);
+    auto agen = AttrsGenerator::parse(attrsScope, _cmd, error);
+    
+    QCOMPARE(agen->command(), _exp_cmd);
 }
 
 void TestAttrsGenerator::tst_parseStarCmd()


### PR DESCRIPTION
Fixes error where Evoplex crashes if the input is an integer or not colon-separated (as addressed in #19 )

Current behavior:

* When passing an integer, the size is set as the input and the function defaults to ``min``

* When passing a non colon-separated value, the generator throws an error