### PR TITLE
Allow to zoom in with the alphanumeric keyboard

### DIFF
--- a/src/gui/basegraphgl.cpp
+++ b/src/gui/basegraphgl.cpp
@@ -375,7 +375,7 @@ void BaseGraphGL::keyPressEvent(QKeyEvent* e)
     if (e->modifiers().testFlag(Qt::ControlModifier)) {
         if (e->key() == Qt::Key_0) {
             resetView();
-        } else if (e->key() == Qt::Key_Plus) {
+        } else if (e->key() == Qt::Key_Plus || e->key() == Qt::Key_Equal) {
             zoomIn();
         } else if (e->key() == Qt::Key_Minus) {
             zoomOut();

--- a/src/gui/basegraphgl.cpp
+++ b/src/gui/basegraphgl.cpp
@@ -377,7 +377,7 @@ void BaseGraphGL::keyPressEvent(QKeyEvent* e)
             resetView();
         } else if (e->key() == Qt::Key_Plus || e->key() == Qt::Key_Equal) {
             zoomIn();
-        } else if (e->key() == Qt::Key_Minus) {
+        } else if (e->key() == Qt::Key_Minus || e->key() == Qt::Key_Underscore) {
             zoomOut();
         }
         QOpenGLWidget::keyPressEvent(e);


### PR DESCRIPTION
Currently you can't zoom in the experiment view using the (alphanumeric) plus key. I did run it on the debugger and found out that the alphanumeric ``+`` keycode is distinct from the one on the numerical keypad.

![](https://i.imgur.com/DU3EDV6.png)

I'm pretty sure there is a more elegant way to achieve this, but I'm still trying to figure out how Qt keyboard events (and the whole framework in general) work.