### PR TITLE
Edge selection/deletion from the Graph Viewer

### DIFF
--- a/src/gui/basegraphgl.cpp
+++ b/src/gui/basegraphgl.cpp
@@ -269,9 +269,9 @@ void BaseGraphGL::removeEdgeEvent()
     int edgeId = (m_ui->edgeId->text()).toInt();
     const Edge e = m_trial->graph()->edge(edgeId);
     m_trial->graph()->removeEdge(e);
-    updateCache(true);
     m_ui->inspector->hide();
-
+    clearSelection();
+    updateCache(true);
 }
 
 void BaseGraphGL::setNodeCMap(ColorMap* cmap)
@@ -369,12 +369,14 @@ void BaseGraphGL::mouseReleaseEvent(QMouseEvent *e)
         if (!m_nodeCur.isNull() && !prevSelection.isNull() && m_nodeCur != prevSelection && pressed_ctrl) {
             clearSelection();
             updateEdgesInspector(m_nodeCur, prevSelection);
+            m_bCenter->isChecked() ? updateCache() : update();
         }
         else if (e->pos() == m_posEntered) {
             if (node.isNull() || prevSelection == node) {
                 clearSelection();
             } else {
                 updateInspector(node);
+                setSelectedNode(node, false);
                 m_bCenter->isChecked() ? updateCache() : update();
             }
         } else if(!m_nodeCur.isNull() && !node.isNull() && node != m_nodeCur){
@@ -482,6 +484,12 @@ void BaseGraphGL::updateEdgesInspector(const Node& pnode, const Node& cnode)
             edges.insert(e.first);
         }
     }
+    
+    if (edges.size() == 0){
+            return;
+    }
+    
+    setSelectedNode(pnode, true);
     
     // If there is only one edge to the target node, open the edgeInspector directly
     if (edges.size() == 1)

--- a/src/gui/basegraphgl.cpp
+++ b/src/gui/basegraphgl.cpp
@@ -369,11 +369,11 @@ void BaseGraphGL::mouseReleaseEvent(QMouseEvent *e)
             updateEdgesInspector(nodeCur, prevSelection);
             m_bCenter->isChecked() ? updateCache() : update();
         } else if (e->pos() == m_posEntered) {
-            if (node.isNull() || prevSelection == node) {
-                clearSelection();
-            } else {
+            clearSelection();
+            if (!node.isNull() && prevSelection != node) {
                 updateInspector(node);
                 setSelectedNode(node, false);
+                selectNode(e->localPos(), m_bCenter->isChecked());
                 m_bCenter->isChecked() ? updateCache() : update();
             }
         } else {

--- a/src/gui/basegraphgl.cpp
+++ b/src/gui/basegraphgl.cpp
@@ -378,6 +378,7 @@ void BaseGraphGL::mouseReleaseEvent(QMouseEvent *e)
                 m_bCenter->isChecked() ? updateCache() : update();
             }
         } else if(!m_nodeCur.isNull() && !node.isNull() && node != m_nodeCur){
+            clearSelection();
             m_trial->graph()->addEdge(m_nodeCur.id(), node.id());
             updateCache(true);
         } else {

--- a/src/gui/basegraphgl.h
+++ b/src/gui/basegraphgl.h
@@ -92,8 +92,6 @@ protected:
     qreal m_nodeRadius;
     QPointF m_origin;
     
-    bool pressed_ctrl;
-
     CacheStatus m_cacheStatus;
 
     CacheStatus refreshCache() override { return CacheStatus::Ready; }

--- a/src/gui/basegraphgl.h
+++ b/src/gui/basegraphgl.h
@@ -60,6 +60,7 @@ protected:
     virtual bool selectNode(const Node& node, bool center) = 0;
     virtual Node selectedNode() const = 0;
     virtual QPointF selectedNodePos() const = 0;
+    virtual void setSelectedNode(const Node& node, bool ctrl){};
     virtual void clearSelection() = 0;
     virtual CacheStatus refreshCache() = 0;
 };

--- a/src/gui/basegraphgl.h
+++ b/src/gui/basegraphgl.h
@@ -36,6 +36,7 @@
 #include "experimentwidget.h"
 #include "graphwidget.h"
 #include "maingui.h"
+#include <QListWidget>
 
 class Ui_BaseGraphGL;
 
@@ -89,6 +90,8 @@ protected:
     qreal m_nodeScale;
     qreal m_nodeRadius;
     QPointF m_origin;
+    
+    bool pressed_ctrl;
 
     CacheStatus m_cacheStatus;
 
@@ -105,6 +108,7 @@ protected:
     void wheelEvent(QWheelEvent* e) override;
     void keyPressEvent(QKeyEvent* e) override;
     void keyReleaseEvent(QKeyEvent* e) override;
+    
 
 signals:
     void updateWidgets(bool) const;
@@ -122,6 +126,8 @@ private slots:
     void slotRestarted();
     void resetView();
     void setNodeCMap(ColorMap* cmap);
+    void edgesListItemClicked(QListWidgetItem* item);
+    void removeEdgeEvent();
 
 private:
     QtMaterialIconButton* m_bCenter;
@@ -139,6 +145,8 @@ private:
     void setupInspector();
 
     void updateInspector(const Node& node);
+    void updateEdgeInspector(const Edge& edge);
+    void updateEdgesInspector(const Node& pnode, const Node& cnode);
 };
 
 inline void BaseGraphGL::paintEvent(QPaintEvent*)

--- a/src/gui/forms/basegraphgl.ui
+++ b/src/gui/forms/basegraphgl.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>457</width>
-    <height>285</height>
+    <width>588</width>
+    <height>463</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -26,27 +26,8 @@
    <property name="rightMargin">
     <number>20</number>
    </property>
-   <item row="3" column="2">
-    <widget class="QPushButton" name="bReset">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>35</width>
-       <height>10</height>
-      </size>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="2">
-    <widget class="QPushButton" name="bZoomIn">
+   <item row="4" column="2">
+    <widget class="QPushButton" name="bZoomOut">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -60,22 +41,9 @@
       </size>
      </property>
      <property name="text">
-      <string>+</string>
+      <string>-</string>
      </property>
     </widget>
-   </item>
-   <item row="1" column="1" colspan="2">
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>14</width>
-       <height>34</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item row="4" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
@@ -238,8 +206,40 @@ color: rgb(255, 255, 255);</string>
      </property>
     </spacer>
    </item>
-   <item row="4" column="2">
-    <widget class="QPushButton" name="bZoomOut">
+   <item row="1" column="1" colspan="2">
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>14</width>
+       <height>34</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="2">
+    <widget class="QPushButton" name="bReset">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>35</width>
+       <height>10</height>
+      </size>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QPushButton" name="bZoomIn">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
        <horstretch>0</horstretch>
@@ -253,169 +253,509 @@ color: rgb(255, 255, 255);</string>
       </size>
      </property>
      <property name="text">
-      <string>-</string>
+      <string>+</string>
      </property>
     </widget>
    </item>
    <item row="0" column="1" colspan="2">
-    <widget class="QWidget" name="inspector" native="true">
+    <widget class="QStackedWidget" name="inspector">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <property name="topMargin">
-       <number>6</number>
-      </property>
-      <item>
-       <layout class="QHBoxLayout" name="_topLayout">
-        <property name="spacing">
-         <number>0</number>
-        </property>
-        <item>
-         <layout class="QHBoxLayout" name="topLayout">
-          <property name="spacing">
-           <number>7</number>
-          </property>
-         </layout>
-        </item>
-        <item>
-         <spacer name="hspacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QLabel" name="bCloseInspector">
-          <property name="minimumSize">
-           <size>
-            <width>24</width>
-            <height>24</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>24</width>
-            <height>24</height>
-           </size>
-          </property>
-          <property name="lineWidth">
-           <number>0</number>
-          </property>
-          <property name="pixmap">
-           <pixmap resource="../res/guiRes.qrc">:/icons/material/close_white_18</pixmap>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QFormLayout" name="inspectorLayout">
-        <item row="1" column="0">
-         <widget class="QLabel" name="lNodeId">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>80</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>node id</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="lNeighbours">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="minimumSize">
-           <size>
-            <width>80</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>neighbors</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QLineEdit" name="neighbors">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="toolTip">
-           <string>neighbours ids</string>
-          </property>
-          <property name="readOnly">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QSpinBox" name="nodeId">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="buttonSymbols">
-           <enum>QAbstractSpinBox::NoButtons</enum>
-          </property>
-          <property name="minimum">
-           <number>-1</number>
-          </property>
-          <property name="maximum">
-           <number>1000000000</number>
-          </property>
-          <property name="value">
-           <number>-1</number>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QFormLayout" name="modelAttrs">
-        <property name="formAlignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-       </layout>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-     </layout>
+     <property name="autoFillBackground">
+      <bool>false</bool>
+     </property>
+     <property name="currentIndex">
+      <number>1</number>
+     </property>
+     <widget class="QWidget" name="nodeInspector">
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="topMargin">
+        <number>6</number>
+       </property>
+       <item>
+        <layout class="QHBoxLayout" name="_topLayout">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <item>
+          <layout class="QHBoxLayout" name="topLayout">
+           <property name="spacing">
+            <number>7</number>
+           </property>
+          </layout>
+         </item>
+         <item>
+          <spacer name="hspacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="bCloseInspector">
+           <property name="minimumSize">
+            <size>
+             <width>24</width>
+             <height>24</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>24</width>
+             <height>24</height>
+            </size>
+           </property>
+           <property name="lineWidth">
+            <number>0</number>
+           </property>
+           <property name="pixmap">
+            <pixmap resource="../res/guiRes.qrc">:/icons/material/close_white_18</pixmap>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QFormLayout" name="inspectorLayout">
+         <item row="1" column="0">
+          <widget class="QLabel" name="lNodeId">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>80</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>node id</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="lNeighbours">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>80</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>neighbors</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0">
+          <widget class="QLabel" name="lEdges">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>80</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>connected edges</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QLineEdit" name="edges">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="toolTip">
+            <string>connected edges</string>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLineEdit" name="neighbors">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="toolTip">
+            <string>neighbours ids</string>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QSpinBox" name="nodeId">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="buttonSymbols">
+            <enum>QAbstractSpinBox::NoButtons</enum>
+           </property>
+           <property name="minimum">
+            <number>-1</number>
+           </property>
+           <property name="maximum">
+            <number>1000000000</number>
+           </property>
+           <property name="value">
+            <number>-1</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QFormLayout" name="modelAttrs">
+         <property name="formAlignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="edgeInspector">
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="topMargin">
+        <number>6</number>
+       </property>
+       <item>
+        <layout class="QHBoxLayout" name="_topLayout">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <item>
+          <layout class="QHBoxLayout" name="topLayout">
+           <property name="spacing">
+            <number>7</number>
+           </property>
+          </layout>
+         </item>
+         <item>
+          <spacer name="hspacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="bCloseInspector">
+           <property name="minimumSize">
+            <size>
+             <width>24</width>
+             <height>24</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>24</width>
+             <height>24</height>
+            </size>
+           </property>
+           <property name="lineWidth">
+            <number>0</number>
+           </property>
+           <property name="pixmap">
+            <pixmap resource="../res/guiRes.qrc">:/icons/material/close_white_18</pixmap>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QFormLayout" name="inspectorLayout">
+         <item row="2" column="0">
+          <widget class="QLabel" name="ledgeNeighbours">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>80</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>edge id</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QLineEdit" name="edgeId">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="toolTip">
+            <string>neighbours ids</string>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QPushButton" name="deleteEdge">
+           <property name="text">
+            <string>Delete Edge</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QFormLayout" name="modelAttrs">
+         <property name="formAlignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="edgesInspector">
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="topMargin">
+        <number>6</number>
+       </property>
+       <item>
+        <layout class="QHBoxLayout" name="_topLayout">
+         <property name="spacing">
+          <number>0</number>
+         </property>
+         <item>
+          <layout class="QHBoxLayout" name="topLayout">
+           <property name="spacing">
+            <number>7</number>
+           </property>
+          </layout>
+         </item>
+         <item>
+          <spacer name="hspacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="bCloseInspector">
+           <property name="minimumSize">
+            <size>
+             <width>24</width>
+             <height>24</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>24</width>
+             <height>24</height>
+            </size>
+           </property>
+           <property name="lineWidth">
+            <number>0</number>
+           </property>
+           <property name="pixmap">
+            <pixmap resource="../res/guiRes.qrc">:/icons/material/close_white_18</pixmap>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QFormLayout" name="inspectorLayout">
+         <item row="1" column="0">
+          <widget class="QLabel" name="loriginId">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>80</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>origin node</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="lEdgesIds">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>80</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>connected edges</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QSpinBox" name="originId">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="buttonSymbols">
+            <enum>QAbstractSpinBox::NoButtons</enum>
+           </property>
+           <property name="minimum">
+            <number>-1</number>
+           </property>
+           <property name="maximum">
+            <number>1000000000</number>
+           </property>
+           <property name="value">
+            <number>-1</number>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QLabel" name="ltargetId">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>80</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>target node</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="QListWidget" name="edgesList"/>
+         </item>
+         <item row="2" column="1">
+          <widget class="QSpinBox" name="targetId">
+           <property name="buttonSymbols">
+            <enum>QAbstractSpinBox::NoButtons</enum>
+           </property>
+           <property name="minimum">
+            <number>-1</number>
+           </property>
+           <property name="maximum">
+            <number>1000000000</number>
+           </property>
+           <property name="value">
+            <number>-1</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QFormLayout" name="modelAttrs">
+         <property name="formAlignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>

--- a/src/gui/graphview.cpp
+++ b/src/gui/graphview.cpp
@@ -115,6 +115,7 @@ void GraphView::setSelectedNode(const Node& node, bool ctrl)
     }
     else {
         m_selectedNodeBase = node;
+        m_selectedNodeTar = Node();
     }
 }
 

--- a/src/gui/graphview.cpp
+++ b/src/gui/graphview.cpp
@@ -108,6 +108,16 @@ CacheStatus GraphView::refreshCache()
     return CacheStatus::Ready;
 }
 
+void GraphView::setSelectedNode(const Node& node, bool ctrl)
+{
+    if (ctrl){
+        m_selectedNodeTar = node;
+    }
+    else {
+        m_selectedNodeBase = node;
+    }
+}
+
 Node GraphView::selectNode(const QPointF& pos, bool center)
 {
     m_selectedStar = Star();
@@ -185,7 +195,7 @@ void GraphView::updateNodePen()
 
 void GraphView::paintFrame(QPainter& painter) const
 {
-    if (m_selectedStar.node.isNull()) {
+    if (m_selectedStar.node.isNull() && m_selectedNodeTar.isNull()) {
         painter.setOpacity(1.0);
         drawEdges(painter);
     } else {
@@ -194,6 +204,7 @@ void GraphView::paintFrame(QPainter& painter) const
     const double nodeRadius = m_nodeRadius;
     drawNodes(painter, nodeRadius);
     drawSelectedStar(painter, nodeRadius);
+    drawSelectedEdge(painter, nodeRadius);
 }
 
 void GraphView::drawNode(QPainter& painter, const Star& s, double r) const
@@ -243,6 +254,36 @@ void GraphView::drawEdges(QPainter& painter) const
             }
         }
     }
+    painter.restore();
+}
+
+void GraphView::drawSelectedEdge(QPainter& painter, double nodeRadius) const
+{
+    if (m_selectedNodeTar.isNull() || m_selectedNodeBase.isNull()){
+        return;
+    }
+    
+    painter.setOpacity(1.0);
+    
+    const QPointF p1 = nodePoint(m_selectedNodeBase, currEdgeSize());
+    const QPointF p2 = nodePoint(m_selectedNodeTar, currEdgeSize());
+    
+    painter.save();
+    // highlight immediate edges
+    painter.setPen(QPen(Qt::darkGray, m_edgePen.width() + 3));
+    painter.drawLine(p1.x(), p1.y(), p2.x(), p2.y());
+    
+    // draw selected node
+    painter.setPen(m_nodePen);
+    
+    const Value& value1 = m_selectedNodeBase.attr(m_nodeAttr);
+    painter.setBrush(m_nodeCMap->colorFromValue(value1));
+    painter.drawEllipse(p1, nodeRadius, nodeRadius);
+    
+    const Value& value2 = m_selectedNodeTar.attr(m_nodeAttr);
+    painter.setBrush(m_nodeCMap->colorFromValue(value2));
+    painter.drawEllipse(p2, nodeRadius, nodeRadius);
+    
     painter.restore();
 }
 

--- a/src/gui/graphview.h
+++ b/src/gui/graphview.h
@@ -48,6 +48,7 @@ protected:
     inline QPointF selectedNodePos() const override;
     inline void clearSelection() override;
     CacheStatus refreshCache() override;
+    void setSelectedNode(const Node& node, bool ctrl) override;
 
 private slots:
     void setEdgeCMap(ColorMap* cmap);
@@ -76,11 +77,15 @@ private:
     };
     std::vector<Star> m_cache;
     Star m_selectedStar;
+    Node m_selectedNodeBase;
+    Node m_selectedNodeTar;
+    
     Star createStar(const Node& node, const qreal& edgeSizeRate, const QPointF& xy);
 
     void drawNode(QPainter& painter, const Star& s, double r) const;
     void drawEdges(QPainter& painter) const;
     void drawNodes(QPainter& painter, double nodeRadius) const;
+    void drawSelectedEdge(QPainter& painter, double nodeRadius) const;
     void drawSelectedStar(QPainter& painter, double nodeRadius) const;
 
     inline qreal currEdgeSize() const;
@@ -94,7 +99,11 @@ inline QPointF GraphView::selectedNodePos() const
 { return m_selectedStar.xy + m_origin; }
 
 inline void GraphView::clearSelection()
-{ m_selectedStar = Star(); BaseGraphGL::clearSelection(); }
+{ 
+    m_selectedStar = Star();
+    m_selectedNodeTar = Node();
+    BaseGraphGL::clearSelection(); 
+}
 
 inline void GraphView::zoomIn()
 { updateNodePen(); BaseGraphGL::zoomIn(); }


### PR DESCRIPTION
This is a draft PR

What changed
---------------

- Three inspector views:

    - The base inspector is pretty much unchanged, the only difference being that it now displays the neighbouring edges.
    - The edges inspector displays every edge that connect two selected nodes. Each edge is clickable and leads you to the corresponding ...
    - Edge inspector that displays a specific edge. It also gives you the option to delete the specific edge.

- Workflow:

    - Simply connect two nodes to create an edge
    - If you've already selected a node, press ctrl + click on another node to open the edges inspector.
    - Clicking on any listed edge Id to open the edge inspector

- Possible improvements/changes before merging:

    - Dynamically resize the inspector so it doesn't take up unnecessary space.
    - Make the controls more user-friendly
    - Highlight the nodes when opening the edge/edges editor
    - Display/edit edge attributes
