### PR TITLE
Fix error when creating star with edge attributes

### DIFF
--- a/src/plugins/graphs/star/plugin.cpp
+++ b/src/plugins/graphs/star/plugin.cpp
@@ -44,10 +44,12 @@ bool StarGraph::reset()
     // which will always start from 0 and end at size-1
     node(0).setCoords(radius, radius);
     if (m_edgeAttrsGen) {
-        auto soa = m_edgeAttrsGen->create(nNodes);
-        for (int nodeId = 1; nodeId < nNodes; ++nodeId) {
+        auto setOfAttrs = m_edgeAttrsGen->create(nNodes - 1);
+        int nodeId = 1;
+        for (auto& attrs : setOfAttrs) {
             fixCoords(node(nodeId), radius, dTheta);
-            addEdge(0, nodeId, new Attributes(soa.at(nodeId)));
+            addEdge(0, nodeId, new Attributes(attrs));
+            ++nodeId;
         }
     } else {
         for (int nodeId = 1; nodeId < nNodes; ++nodeId) {

--- a/src/plugins/graphs/star/plugin.cpp
+++ b/src/plugins/graphs/star/plugin.cpp
@@ -44,7 +44,7 @@ bool StarGraph::reset()
     // which will always start from 0 and end at size-1
     node(0).setCoords(radius, radius);
     if (m_edgeAttrsGen) {
-        auto soa = m_edgeAttrsGen->create(nNodes - 1);
+        auto soa = m_edgeAttrsGen->create(nNodes);
         for (int nodeId = 1; nodeId < nNodes; ++nodeId) {
             fixCoords(node(nodeId), radius, dTheta);
             addEdge(0, nodeId, new Attributes(soa.at(nodeId)));


### PR DESCRIPTION
There is an error when attempting to create a star graph where ``soa`` will contain the valid indices from 0 to ``nNodes`` - 2 so it results in segmentation fault when later attempting to call ``soa.at(nNodes - 1)``