### PR TITLE
graphattrsdlg: Display set attributes

### DIFF
--- a/src/gui/graphattrsdlg.cpp
+++ b/src/gui/graphattrsdlg.cpp
@@ -20,6 +20,8 @@
 
 #include <QDebug>
 #include <QSet>
+#include <QTableWidgetItem>
+#include <QHash>
 #include <QMessageBox>
 
 #include "graphattrsdlg.h"
@@ -41,11 +43,35 @@ GraphAttrsDlg::GraphAttrsDlg(GraphDesignerPage* parent, const AttrsType type)
     connect(m_ui->numAttrs, SIGNAL(valueChanged(int)), SLOT(slotTableUpdate(int)));
     connect(m_ui->ok, SIGNAL(clicked()), SLOT(slotAttrSaved()));
     connect(m_ui->cancel, SIGNAL(clicked()), SLOT(close()));
+
+    if ((m_type == AttrsType::Nodes && !m_graphPage->nodeAttributesScope().isEmpty()) ||
+        (m_type == AttrsType::Edges && !m_graphPage->edgeAttributesScope().isEmpty())) {
+        displayCurrentAttrs();
+    }
 };
 
 GraphAttrsDlg::~GraphAttrsDlg()
 {
     delete m_ui;
+}
+
+void GraphAttrsDlg::displayCurrentAttrs()
+{
+    AttributesScope attrsScope;
+    if (m_type == AttrsType::Nodes) {
+        attrsScope = m_graphPage->nodeAttributesScope();
+    } else {
+        attrsScope = m_graphPage->edgeAttributesScope();
+    }
+
+    m_ui->numAttrs->setValue(attrsScope.size());
+    int i = 0;
+    
+    for (auto attrRange : attrsScope) {    
+        m_ui->table->setItem(i, 0, new QTableWidgetItem(attrRange->attrName()));
+        m_ui->table->setItem(i, 1, new QTableWidgetItem(attrRange->attrRangeStr()));
+        ++i;
+    }
 }
 
 void GraphAttrsDlg::parseAttributes(QString& error)

--- a/src/gui/graphattrsdlg.cpp
+++ b/src/gui/graphattrsdlg.cpp
@@ -21,7 +21,6 @@
 #include <QDebug>
 #include <QSet>
 #include <QTableWidgetItem>
-#include <QHash>
 #include <QMessageBox>
 
 #include "graphattrsdlg.h"

--- a/src/gui/graphattrsdlg.h
+++ b/src/gui/graphattrsdlg.h
@@ -60,6 +60,7 @@ private:
     const AttrsType m_type;
 
     void parseAttributes(QString& error);
+    void displayCurrentAttrs();
 };
 
 } // evoplex

--- a/src/gui/graphdesignerpage.cpp
+++ b/src/gui/graphdesignerpage.cpp
@@ -48,28 +48,7 @@ GraphDesignerPage::GraphDesignerPage(MainGUI* mainGUI)
 
     connect(m_ui->acEdgeAttrs, SIGNAL(triggered()), SLOT(slotEdgeAttrs()));
     connect(m_ui->acNodeAttrs, SIGNAL(triggered()), SLOT(slotNodeAttrs()));
-    connect(m_ui->acGraphGen, &QAction::triggered, [this]() {
-        if (m_numNodes > 0) {
-            QMessageBox msgBox;
-            msgBox.setText("You are attempting to create a new graph, this will reset your current progress.");
-            msgBox.setInformativeText("Do you want to continue?");
-            msgBox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
-            msgBox.setDefaultButton(QMessageBox::Ok);
-            int but = msgBox.exec();
-            switch (but) {
-            case QMessageBox::Ok:
-                this->slotGraphGen();
-                break;
-            case QMessageBox::Cancel:
-                break;
-            }
-        } else if (!this->m_nodeAttrScope.isEmpty()) {
-            this->slotGraphGen();
-        } else {
-            QMessageBox::warning(this, "Graph Generator",
-            "Make sure you have set valid node attributes before attempting to open the graph generator");
-        }
-    });
+    connect(m_ui->acGraphGen, SIGNAL(triggered()), SLOT(slotGraphGen()));
     connect(m_ui->acGraphSettings, SIGNAL(triggered()), m_graphDesigner, SLOT(slotOpenSettings()));
     connect(m_ui->acNodesExporter, SIGNAL(triggered()), m_graphDesigner, SLOT(slotExportNodes()));
 
@@ -85,12 +64,32 @@ void GraphDesignerPage::slotEdgeAttrs() {
     new GraphAttrsDlg(this, AttrsType::Edges);
 }
 
+void GraphDesignerPage::slotGraphGen() {
+    if (m_numNodes > 0) {
+        QMessageBox msgBox;
+        msgBox.setText("You are attempting to create a new graph, this will reset your current progress.");
+        msgBox.setInformativeText("Do you want to continue?");
+        msgBox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
+        msgBox.setDefaultButton(QMessageBox::Ok);
+        if (msgBox.exec() == QMessageBox::Ok) {
+            graphGen();
+        }
+    }
+    else if (!this->m_nodeAttrScope.isEmpty()) {
+        graphGen();
+    }
+    else {
+        QMessageBox::warning(this, "Graph Generator",
+            "Make sure you have set valid node attributes before attempting to open the graph generator");
+    }
+}
+    
 void GraphDesignerPage::slotNodeAttrs()
 {
     new GraphAttrsDlg(this, AttrsType::Nodes);
 }
 
-void GraphDesignerPage::slotGraphGen()
+void GraphDesignerPage::graphGen()
 {
     new GraphGenDlg(this, m_mainGUI);
 }

--- a/src/gui/graphdesignerpage.cpp
+++ b/src/gui/graphdesignerpage.cpp
@@ -49,7 +49,21 @@ GraphDesignerPage::GraphDesignerPage(MainGUI* mainGUI)
     connect(m_ui->acEdgeAttrs, SIGNAL(triggered()), SLOT(slotEdgeAttrs()));
     connect(m_ui->acNodeAttrs, SIGNAL(triggered()), SLOT(slotNodeAttrs()));
     connect(m_ui->acGraphGen, &QAction::triggered, [this]() {
-        if (!this->m_nodeAttrScope.isEmpty()) {
+        if (m_numNodes > 0) {
+            QMessageBox msgBox;
+            msgBox.setText("You are attempting to create a new graph, this will reset your current progress.");
+            msgBox.setInformativeText("Do you want to continue?");
+            msgBox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
+            msgBox.setDefaultButton(QMessageBox::Ok);
+            int but = msgBox.exec();
+            switch (but) {
+            case QMessageBox::Ok:
+                this->slotGraphGen();
+                break;
+            case QMessageBox::Cancel:
+                break;
+            }
+        } else if (!this->m_nodeAttrScope.isEmpty()) {
             this->slotGraphGen();
         } else {
             QMessageBox::warning(this, "Graph Generator",

--- a/src/gui/graphdesignerpage.cpp
+++ b/src/gui/graphdesignerpage.cpp
@@ -72,13 +72,11 @@ void GraphDesignerPage::slotGraphGen() {
         msgBox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
         msgBox.setDefaultButton(QMessageBox::Ok);
         if (msgBox.exec() == QMessageBox::Ok) {
-            graphGen();
+            new GraphGenDlg(this, m_mainGUI);
         }
-    }
-    else if (!this->m_nodeAttrScope.isEmpty()) {
-        graphGen();
-    }
-    else {
+    } else if (!this->m_nodeAttrScope.isEmpty()) {
+        new GraphGenDlg(this, m_mainGUI);
+    } else {
         QMessageBox::warning(this, "Graph Generator",
             "Make sure you have set valid node attributes before attempting to open the graph generator");
     }
@@ -87,11 +85,6 @@ void GraphDesignerPage::slotGraphGen() {
 void GraphDesignerPage::slotNodeAttrs()
 {
     new GraphAttrsDlg(this, AttrsType::Nodes);
-}
-
-void GraphDesignerPage::graphGen()
-{
-    new GraphGenDlg(this, m_mainGUI);
 }
 
 void GraphDesignerPage::changedAttrsScope(const AttrsType type, AttributesScope attrs)

--- a/src/gui/graphdesignerpage.h
+++ b/src/gui/graphdesignerpage.h
@@ -56,6 +56,7 @@ protected:
     void changedAttrsScope(const AttrsType type, AttributesScope attrs);
     void changedGraphAttrs(const int numNodes, PluginKey selectedGraphKey, GraphType graphType, QStringList& graphAttrHeader, 
         QStringList& graphAttrValues, QString& error);
+    void graphGen();
 
     inline AttributesScope edgeAttributesScope() const;
     inline AttributesScope nodeAttributesScope() const;

--- a/src/gui/graphdesignerpage.h
+++ b/src/gui/graphdesignerpage.h
@@ -56,7 +56,6 @@ protected:
     void changedAttrsScope(const AttrsType type, AttributesScope attrs);
     void changedGraphAttrs(const int numNodes, PluginKey selectedGraphKey, GraphType graphType, QStringList& graphAttrHeader, 
         QStringList& graphAttrValues, QString& error);
-    void graphGen();
 
     inline AttributesScope edgeAttributesScope() const;
     inline AttributesScope nodeAttributesScope() const;


### PR DESCRIPTION
This allows the graph attributes widget to "remember" the edge/nodes attributes instead of forcing the users to retype everything. It also displays a warning message when attempting to create a new graph with the graph designer, informing the user that this will essentially delete their current progress.