### PR TITLE
Add nodeEdit mode

### DIFF
--- a/src/gui/basegraphgl.cpp
+++ b/src/gui/basegraphgl.cpp
@@ -154,6 +154,14 @@ void BaseGraphGL::createNode(QPointF pos)
     updateCache();
 }
 
+void BaseGraphGL::deleteNode(QPointF pos)
+{
+    const Node& node = findNode(pos);
+    clearSelection();
+    m_abstractGraph->removeNode(node);
+    updateCache();
+}
+
 void BaseGraphGL::setupInspector()
 {
     // important! for some reason, changing the layout (add/delete itens)
@@ -379,9 +387,9 @@ void BaseGraphGL::mouseReleaseEvent(QMouseEvent *e)
         return;
     }
 
+    const Node& node = findNode(e->localPos());
     if (e->button() == Qt::LeftButton) {
         bool fNodeSelected;
-        const Node& node = findNode(e->localPos());
         Node prevSelection = selectedNode();
 
         if (!node.isNull() && inSelectedNodes(node)) {
@@ -413,6 +421,8 @@ void BaseGraphGL::mouseReleaseEvent(QMouseEvent *e)
             m_origin += (e->pos() - m_posEntered);
             updateCache();
         }
+    } else if (e->button() == Qt::RightButton && m_curMode == SelectionMode::NodeEdit && !node.isNull()) {
+        deleteNode(e->localPos());
     } else if (e->button() == Qt::RightButton && m_nodeAttr >= 0 && !m_isReadOnly) {
         Node node = selectNode(e->localPos(), false);
         if (!node.isNull()) {

--- a/src/gui/basegraphgl.cpp
+++ b/src/gui/basegraphgl.cpp
@@ -55,8 +55,8 @@ BaseGraphGL::BaseGraphGL(QWidget* parent)
     connect(m_ui->bZoomIn, SIGNAL(pressed()), SLOT(zoomIn()));
     connect(m_ui->bZoomOut, SIGNAL(pressed()), SLOT(zoomOut()));
     connect(m_ui->bReset, SIGNAL(pressed()), SLOT(resetView()));
-    //connect(m_ui->edgesList, SIGNAL(itemClicked(QListWidgetItem*)), this, SLOT(edgesListItemClicked(QListWidgetItem*)));
     connect(m_ui->deleteEdge, SIGNAL(clicked()), this, SLOT(removeEdgeEvent()));
+    
     m_bCenter = new QtMaterialIconButton(QIcon(":/icons/material/center_white_18"), this);
     m_bCenter->setToolTip("centralize selection");
     m_bCenter->setCheckable(true);

--- a/src/gui/basegraphgl.cpp
+++ b/src/gui/basegraphgl.cpp
@@ -57,6 +57,8 @@ BaseGraphGL::BaseGraphGL(QWidget* parent)
     connect(m_ui->bReset, SIGNAL(pressed()), SLOT(resetView()));
     connect(m_ui->deleteEdge, SIGNAL(clicked()), this, SLOT(removeEdgeEvent()));
     
+    connect(this, SIGNAL(nodesMoved()), SLOT(slotUpdateSelection()));
+
     m_bCenter = new QtMaterialIconButton(QIcon(":/icons/material/center_white_18"), this);
     m_bCenter->setToolTip("centralize selection");
     m_bCenter->setCheckable(true);
@@ -147,14 +149,14 @@ void BaseGraphGL::slotDeleteSelectedNodes()
     updateCache();
 }
 
-void BaseGraphGL::createNode(QPointF pos)
+void BaseGraphGL::createNode(const QPointF pos)
 {
     QPointF p = nodePoint(pos - m_origin);
     m_abstractGraph->addNode(m_attrs, p.x(), p.y());
     updateCache();
 }
 
-void BaseGraphGL::deleteNode(QPointF pos)
+void BaseGraphGL::deleteNode(const QPointF pos)
 {
     const Node& node = findNode(pos);
     clearSelection();
@@ -162,17 +164,19 @@ void BaseGraphGL::deleteNode(QPointF pos)
     updateCache();
 }
 
-void BaseGraphGL::moveSelectedNodes(Node& node, QPointF pos) {
+void BaseGraphGL::moveSelectedNodes(Node& node, const QPointF pos) {
     QPointF v = nodePoint(pos - m_origin) - QPointF(node.x(), node.y());
     for (Node _node : m_selectedNodes) {
         _node.setCoords(_node.x() + v.x(), _node.y() + v.y());
     }
+    emit(nodesMoved());
     updateCache();
 }
 
 void BaseGraphGL::moveNode(Node& node, QPointF pos) {
     QPointF p = nodePoint(pos - m_origin);
     node.setCoords(p.x(), p.y());
+    emit(nodesMoved());
     updateCache();
 }
 

--- a/src/gui/basegraphgl.cpp
+++ b/src/gui/basegraphgl.cpp
@@ -401,8 +401,8 @@ void BaseGraphGL::mouseReleaseEvent(QMouseEvent *e)
         return;
     }
 
-    Node& prevNode = findNode(m_posEntered);
-    Node& node = findNode(e->localPos());
+    Node prevNode = findNode(m_posEntered);
+    Node node = findNode(e->localPos());
     if (e->button() == Qt::LeftButton) {
         bool fNodeSelected;
         Node prevSelection = selectedNode();

--- a/src/gui/basegraphgl.cpp
+++ b/src/gui/basegraphgl.cpp
@@ -426,7 +426,15 @@ void BaseGraphGL::mouseReleaseEvent(QMouseEvent *e)
 
         if (e->pos() == m_posEntered) {
             if (!e->modifiers().testFlag(Qt::ControlModifier)) {
-                clearSelection();
+                if (m_curMode == SelectionMode::NodeEdit && node.isNull()) {
+                    if (m_selectedNodes.empty()) {
+                        createNode(e->localPos());
+                    } else {
+                        clearSelection();
+                    }
+                } else {
+                    clearSelection();
+                }
             }
             if (!node.isNull() && (!fNodeSelected || !e->modifiers().testFlag(Qt::ControlModifier))) {
                 selectNode(e->localPos(), m_bCenter->isChecked());
@@ -434,8 +442,6 @@ void BaseGraphGL::mouseReleaseEvent(QMouseEvent *e)
                 updateInspector(node);
                 emit(nodeSelected(node));
                 refreshCache();
-            } else if (m_curMode == SelectionMode::NodeEdit && node.isNull()) {
-                createNode(e->localPos());
             }
             m_bCenter->isChecked() ? updateCache() : update();
         } else {

--- a/src/gui/basegraphgl.cpp
+++ b/src/gui/basegraphgl.cpp
@@ -173,7 +173,7 @@ void BaseGraphGL::moveSelectedNodes(Node& node, const QPointF pos) {
     updateCache();
 }
 
-void BaseGraphGL::moveNode(Node& node, QPointF pos) {
+void BaseGraphGL::moveNode(Node& node, const QPointF pos) {
     QPointF p = nodePoint(pos - m_origin);
     node.setCoords(p.x(), p.y());
     emit(nodesMoved());

--- a/src/gui/basegraphgl.h
+++ b/src/gui/basegraphgl.h
@@ -167,6 +167,9 @@ private:
 
     void attrValueChanged(int attrId) const;
 
+    void moveSelectedNodes(Node& node, QPointF pos);
+    void moveNode(Node& node, QPointF pos);
+
     void setupInspector();
 
     void updateInspector(const Node& node);

--- a/src/gui/basegraphgl.h
+++ b/src/gui/basegraphgl.h
@@ -61,7 +61,7 @@ class GraphGLInterface
 protected:
     virtual ~GraphGLInterface() = default;
     virtual void paintFrame(QPainter& painter) const = 0;
-    virtual Node findNode(const QPointF& pos) = 0;
+    virtual Node findNode(const QPointF& pos) const = 0;
     virtual Node selectNode(const QPointF& pos, bool center) = 0;
     virtual bool selectNode(const Node& node, bool center) = 0;
     virtual bool deselectNode(const Node& node) = 0;
@@ -69,7 +69,7 @@ protected:
     virtual QPointF selectedNodePos() const = 0;
     virtual void clearSelection() = 0;
     virtual CacheStatus refreshCache() = 0;
-    virtual inline bool inSelectedNodes(const Node node) const = 0;
+    virtual inline bool inSelectedNodes(const Node& node) const = 0;
     virtual inline QPointF nodePoint(const QPointF& pos) = 0;
 
 };
@@ -113,7 +113,7 @@ protected:
 
     void updateCache(bool force=false);
     
-    void createNode(const QPointF pos);
+    void createNode(const QPointF& pos);
     void deleteNode(const QPointF pos);
 
     inline void paintEvent(QPaintEvent*) override;
@@ -169,7 +169,7 @@ private:
 
     void attrValueChanged(int attrId) const;
 
-    void moveSelectedNodes(Node& node, const QPointF pos);
+    void moveSelectedNodes(const Node& node, const QPointF pos);
     void moveNode(Node& node, const QPointF pos);
 
     void setupInspector();

--- a/src/gui/basegraphgl.h
+++ b/src/gui/basegraphgl.h
@@ -112,7 +112,9 @@ protected:
     void clearSelection() override;
 
     void updateCache(bool force=false);
+    
     void createNode(QPointF pos);
+    void deleteNode(QPointF pos);
 
     inline void paintEvent(QPaintEvent*) override;
     void mousePressEvent(QMouseEvent* e) override;

--- a/src/gui/basegraphgl.h
+++ b/src/gui/basegraphgl.h
@@ -135,6 +135,7 @@ public slots:
     void setNodeScale(int v);
     void slotRestarted();
     void slotStatusChanged(Status s);
+    void slotDeleteSelectedNodes();
 
 private slots:
     void slotSelectNode(int nodeid);

--- a/src/gui/basegraphgl.h
+++ b/src/gui/basegraphgl.h
@@ -113,8 +113,8 @@ protected:
 
     void updateCache(bool force=false);
     
-    void createNode(QPointF pos);
-    void deleteNode(QPointF pos);
+    void createNode(const QPointF pos);
+    void deleteNode(const QPointF pos);
 
     inline void paintEvent(QPaintEvent*) override;
     void mousePressEvent(QMouseEvent* e) override;
@@ -128,11 +128,13 @@ signals:
     void nodeSelected(const Node&);
     void nodeDeselected(const Node&);
     void clearedSelected();
+    void nodesMoved();
     void updateWidgets(bool) const;
 
 public slots:
     virtual void zoomIn();
     virtual void zoomOut();
+    virtual void slotUpdateSelection() = 0;
 
     void slotFullInspectorVisible(int visible);
     void setCurrentStep(int step);
@@ -167,8 +169,8 @@ private:
 
     void attrValueChanged(int attrId) const;
 
-    void moveSelectedNodes(Node& node, QPointF pos);
-    void moveNode(Node& node, QPointF pos);
+    void moveSelectedNodes(Node& node, const QPointF pos);
+    void moveNode(Node& node, const QPointF pos);
 
     void setupInspector();
 

--- a/src/gui/basegraphgl.h
+++ b/src/gui/basegraphgl.h
@@ -70,6 +70,8 @@ protected:
     virtual void clearSelection() = 0;
     virtual CacheStatus refreshCache() = 0;
     virtual inline bool inSelectedNodes(const Node node) const = 0;
+    virtual inline QPointF nodePoint(const QPointF& pos) = 0;
+
 };
 
 class BaseGraphGL : public QOpenGLWidget, public GraphGLInterface
@@ -110,6 +112,7 @@ protected:
     void clearSelection() override;
 
     void updateCache(bool force=false);
+    void createNode(QPointF pos);
 
     inline void paintEvent(QPaintEvent*) override;
     void mousePressEvent(QMouseEvent* e) override;
@@ -158,6 +161,7 @@ private:
     bool m_fullInspectorVisible;
     QSet<int> sneighbors;
     QSet<int> sedges;
+    Attributes m_attrs;
 
     void attrValueChanged(int attrId) const;
 

--- a/src/gui/basegraphgl.h
+++ b/src/gui/basegraphgl.h
@@ -61,7 +61,7 @@ class GraphGLInterface
 protected:
     virtual ~GraphGLInterface() = default;
     virtual void paintFrame(QPainter& painter) const = 0;
-    virtual Node findNode(const QPointF& pos) const = 0;
+    virtual Node findNode(const QPointF& pos) = 0;
     virtual Node selectNode(const QPointF& pos, bool center) = 0;
     virtual bool selectNode(const Node& node, bool center) = 0;
     virtual bool deselectNode(const Node& node) = 0;

--- a/src/gui/forms/fullinspector.ui
+++ b/src/gui/forms/fullinspector.ui
@@ -1,143 +1,150 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>FullInspector</class>
- <widget class="QDockWidget" name="FullInspector">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>420</width>
-    <height>558</height>
-   </rect>
-  </property>
-  <property name="minimumSize">
-   <size>
-    <width>300</width>
-    <height>347</height>
-   </size>
-  </property>
-  <property name="features">
-   <set>QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
-  </property>
-  <property name="windowTitle">
-   <string>Full Inspector</string>
-  </property>
-  <widget class="QWidget" name="FullInspectoContents">
-   <layout class="QVBoxLayout" name="verticalLayout">
-    <property name="leftMargin">
-     <number>0</number>
+  <class>FullInspector</class>
+  <widget class="QDockWidget" name="FullInspector">
+    <property name="geometry">
+      <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>420</width>
+        <height>558</height>
+      </rect>
     </property>
-    <property name="rightMargin">
-     <number>0</number>
+    <property name="minimumSize">
+      <size>
+        <width>300</width>
+        <height>400</height>
+      </size>
     </property>
-    <property name="bottomMargin">
-     <number>0</number>
+    <property name="features">
+      <set>QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
     </property>
-    <item>
-     <widget class="QPlainTextEdit" name="textMsg">
-      <property name="enabled">
-       <bool>true</bool>
-      </property>
-      <property name="frameShape">
-       <enum>QFrame::NoFrame</enum>
-      </property>
-      <property name="readOnly">
-       <bool>true</bool>
-      </property>
-      <property name="plainText">
-       <string>Nothing  selected</string>
-      </property>
-      <property name="backgroundVisible">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item>
-     <widget class="QWidget" name="inspectorContents" native="true">
-      <property name="enabled">
-       <bool>true</bool>
-      </property>
-      <layout class="QGridLayout" name="gridLayout">
-       <property name="leftMargin">
-        <number>20</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>20</number>
-       </property>
-       <property name="bottomMargin">
-        <number>20</number>
-       </property>
-       <property name="horizontalSpacing">
-        <number>0</number>
-       </property>
-       <property name="verticalSpacing">
-        <number>30</number>
-       </property>
-       <item row="2" column="0">
-        <widget class="QLabel" name="lattrs">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>40</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="text">
-          <string>Attributes:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <spacer name="verticalSpacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="1" column="0" colspan="2">
-        <widget class="QListWidget" name="ids">
-         <property name="baseSize">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="lids">
-         <property name="text">
-          <string>Ids:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0" colspan="2">
-        <layout class="QFormLayout" name="attrs">
-         <property name="formAlignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-         </property>
-        </layout>
-       </item>
+    <property name="windowTitle">
+      <string>Full Inspector</string>
+    </property>
+    <widget class="QWidget" name="FullInspectoContents">
+      <layout class="QVBoxLayout" name="verticalLayout">
+        <property name="leftMargin">
+          <number>0</number>
+        </property>
+        <property name="rightMargin">
+          <number>0</number>
+        </property>
+        <property name="bottomMargin">
+          <number>0</number>
+        </property>
+        <item>
+          <widget class="QPlainTextEdit" name="textMsg">
+            <property name="enabled">
+              <bool>true</bool>
+            </property>
+            <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+            </property>
+            <property name="readOnly">
+              <bool>true</bool>
+            </property>
+            <property name="plainText">
+              <string>Nothing  selected</string>
+            </property>
+            <property name="backgroundVisible">
+              <bool>true</bool>
+            </property>
+          </widget>
+        </item>
+        <item>
+          <widget class="QWidget" name="inspectorContents" native="true">
+            <property name="enabled">
+              <bool>true</bool>
+            </property>
+            <layout class="QGridLayout" name="gridLayout">
+              <property name="leftMargin">
+                <number>20</number>
+              </property>
+              <property name="topMargin">
+                <number>0</number>
+              </property>
+              <property name="rightMargin">
+                <number>20</number>
+              </property>
+              <property name="bottomMargin">
+                <number>20</number>
+              </property>
+              <property name="horizontalSpacing">
+                <number>0</number>
+              </property>
+              <property name="verticalSpacing">
+                <number>30</number>
+              </property>
+              <item row="2" column="0">
+                <widget class="QLabel" name="lattrs">
+                  <property name="sizePolicy">
+                    <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                    </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                    <size>
+                      <width>40</width>
+                      <height>0</height>
+                    </size>
+                  </property>
+                  <property name="text">
+                    <string>Attributes:</string>
+                  </property>
+                </widget>
+              </item>
+              <item row="3" column="0" colspan="2">
+                <layout class="QFormLayout" name="attrs">
+                  <property name="formAlignment">
+                    <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                  </property>
+                </layout>
+              </item>
+              <item row="1" column="0" colspan="2">
+                <widget class="QListWidget" name="ids">
+                  <property name="baseSize">
+                    <size>
+                      <width>0</width>
+                      <height>0</height>
+                    </size>
+                  </property>
+                </widget>
+              </item>
+              <item row="0" column="0">
+                <widget class="QLabel" name="lids">
+                  <property name="text">
+                    <string>Ids:</string>
+                  </property>
+                </widget>
+              </item>
+              <item row="5" column="1">
+                <spacer name="verticalSpacer">
+                  <property name="orientation">
+                    <enum>Qt::Vertical</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                    <size>
+                      <width>20</width>
+                      <height>40</height>
+                    </size>
+                  </property>
+                </spacer>
+              </item>
+              <item row="4" column="0" colspan="2">
+                <widget class="QPushButton" name="bdelete">
+                  <property name="text">
+                    <string>Delete</string>
+                  </property>
+                </widget>
+              </item>
+            </layout>
+          </widget>
+        </item>
       </layout>
-     </widget>
-    </item>
-   </layout>
+    </widget>
   </widget>
- </widget>
- <resources/>
- <connections/>
+  <resources/>
+  <connections/>
 </ui>

--- a/src/gui/fullinspector.cpp
+++ b/src/gui/fullinspector.cpp
@@ -28,16 +28,39 @@ namespace evoplex {
 FullInspector::FullInspector(QWidget* parent)
     : QDockWidget(parent),
       m_ui(new Ui_FullInspector),
-      m_parent(parent)
-{
+      m_parent(parent),
+      m_inspMode(InspectorMode::Select)
+{   
     m_ui->setupUi(this);
     m_ui->inspectorContents->hide();
+    m_ui->bdelete->hide();
+
+    connect(m_ui->bdelete, SIGNAL(clicked()), SLOT(slotDelete()));
 }
 
 FullInspector::~FullInspector() 
 {
     delete m_ui;
     m_attrWidgets.clear();
+}
+
+void FullInspector::updateInspectorView() {
+    if (m_inspMode == InspectorMode::Select) {
+        m_ui->bdelete->hide();
+    } else if (m_inspMode == InspectorMode::Node){
+        m_ui->bdelete->show();
+        m_ui->bdelete->setText("Delete Nodes");
+    } else if (m_inspMode == InspectorMode::Edge) {
+        m_ui->bdelete->show();
+        m_ui->bdelete->setText("Delete Edges");
+    }
+}
+
+void FullInspector::slotChangeInspectorMode(InspectorMode inspMode) {
+    if (m_inspMode != inspMode){
+        m_inspMode = inspMode;
+        updateInspectorView();
+    }
 }
 
 void FullInspector::slotClear() {
@@ -74,6 +97,15 @@ void FullInspector::slotChangeAttrScope(AttributesScope nodeAttrScope)
         l->setMinimumWidth(m_ui->lattrs->minimumWidth());
     }
 
+}
+
+void FullInspector::slotDelete()
+{
+    if (m_inspMode == InspectorMode::Node) {
+        m_ui->ids->clear();
+        m_selectedNodes.clear();
+        emit(deleteNodes());
+    }
 }
 
 void FullInspector::attrValueChanged(int attrId) const

--- a/src/gui/fullinspector.cpp
+++ b/src/gui/fullinspector.cpp
@@ -81,7 +81,7 @@ void FullInspector::slotChangeAttrScope(AttributesScope nodeAttrScope)
 void FullInspector::slotDelete()
 {
     m_ui->ids->clear();
-    if (m_selectedNodes.size() > 1) {
+    if (m_selectedNodes.size() > 0) {
         m_selectedNodes.clear();
         emit(deleteNodes());
     }

--- a/src/gui/fullinspector.cpp
+++ b/src/gui/fullinspector.cpp
@@ -28,12 +28,10 @@ namespace evoplex {
 FullInspector::FullInspector(QWidget* parent)
     : QDockWidget(parent),
       m_ui(new Ui_FullInspector),
-      m_parent(parent),
-      m_inspMode(InspectorMode::Select)
+      m_parent(parent)
 {   
     m_ui->setupUi(this);
     m_ui->inspectorContents->hide();
-    m_ui->bdelete->hide();
 
     connect(m_ui->bdelete, SIGNAL(clicked()), SLOT(slotDelete()));
 }
@@ -42,25 +40,6 @@ FullInspector::~FullInspector()
 {
     delete m_ui;
     m_attrWidgets.clear();
-}
-
-void FullInspector::updateInspectorView() {
-    if (m_inspMode == InspectorMode::Select) {
-        m_ui->bdelete->hide();
-    } else if (m_inspMode == InspectorMode::Node){
-        m_ui->bdelete->show();
-        m_ui->bdelete->setText("Delete Nodes");
-    } else if (m_inspMode == InspectorMode::Edge) {
-        m_ui->bdelete->show();
-        m_ui->bdelete->setText("Delete Edges");
-    }
-}
-
-void FullInspector::slotChangeInspectorMode(InspectorMode inspMode) {
-    if (m_inspMode != inspMode){
-        m_inspMode = inspMode;
-        updateInspectorView();
-    }
 }
 
 void FullInspector::slotClear() {
@@ -101,8 +80,8 @@ void FullInspector::slotChangeAttrScope(AttributesScope nodeAttrScope)
 
 void FullInspector::slotDelete()
 {
-    if (m_inspMode == InspectorMode::Node) {
-        m_ui->ids->clear();
+    m_ui->ids->clear();
+    if (m_selectedNodes.size() > 1) {
         m_selectedNodes.clear();
         emit(deleteNodes());
     }

--- a/src/gui/fullinspector.h
+++ b/src/gui/fullinspector.h
@@ -32,12 +32,6 @@ class Ui_FullInspector;
 
 namespace evoplex {
 
-enum class InspectorMode {
-    Select = 0, // Selection mode
-    Node = 1,   // Node tool
-    Edge = 2    // Edge tool
-};
-
 class FullInspector : public QDockWidget
 {
     Q_OBJECT
@@ -54,20 +48,17 @@ public slots:
     void slotDeselectedNode(const Node& node);
     void slotDelete();
     void slotChangeAttrScope(AttributesScope nodeAttrScope);
-    void slotChangeInspectorMode(InspectorMode inspMode);
 
 signals:
     void deleteNodes();
 
 private:
-    InspectorMode m_inspMode;
     QWidget* m_parent;
     Ui_FullInspector* m_ui;
     std::map<int, Node> m_selectedNodes;
     std::vector<std::shared_ptr<AttrWidget>> m_attrWidgets;
 
     void attrValueChanged(int attrId) const;
-    void updateInspectorView();
 };
 
 }

--- a/src/gui/fullinspector.h
+++ b/src/gui/fullinspector.h
@@ -32,6 +32,12 @@ class Ui_FullInspector;
 
 namespace evoplex {
 
+enum class InspectorMode {
+    Select = 0, // Selection mode
+    Node = 1,   // Node tool
+    Edge = 2    // Edge tool
+};
+
 class FullInspector : public QDockWidget
 {
     Q_OBJECT
@@ -46,16 +52,22 @@ public slots:
     void slotShow();
     void slotSelectedNode(const Node& node);
     void slotDeselectedNode(const Node& node);
+    void slotDelete();
     void slotChangeAttrScope(AttributesScope nodeAttrScope);
+    void slotChangeInspectorMode(InspectorMode inspMode);
 
+signals:
+    void deleteNodes();
 
 private:
+    InspectorMode m_inspMode;
     QWidget* m_parent;
     Ui_FullInspector* m_ui;
     std::map<int, Node> m_selectedNodes;
     std::vector<std::shared_ptr<AttrWidget>> m_attrWidgets;
 
     void attrValueChanged(int attrId) const;
+    void updateInspectorView();
 };
 
 }

--- a/src/gui/graphdesignerpage.cpp
+++ b/src/gui/graphdesignerpage.cpp
@@ -74,9 +74,18 @@ GraphDesignerPage::GraphDesignerPage(MainGUI* mainGUI)
     connect(m_ui->acGraphSettings, SIGNAL(triggered()), m_graphDesigner, SLOT(slotOpenSettings()));
     connect(m_ui->acNodesExporter, SIGNAL(triggered()), m_graphDesigner, SLOT(slotExportNodes()));
     
-    connect(m_ui->acSelectTool, &QAction::triggered, [this]() { this->m_graphDesigner->slotChangeSelectionMode(SelectionMode::Select); });
-    connect(m_ui->acNodeTool, &QAction::triggered, [this]() { this->m_graphDesigner->slotChangeSelectionMode(SelectionMode::NodeEdit); });
-    connect(m_ui->acEdgeTool, &QAction::triggered, [this]() { this->m_graphDesigner->slotChangeSelectionMode(SelectionMode::EdgeEdit); });
+    connect(m_ui->acSelectTool, &QAction::triggered, [this]() { 
+        this->m_graphDesigner->slotChangeSelectionMode(SelectionMode::Select); 
+        this->m_inspector->slotChangeInspectorMode(InspectorMode::Select);
+    });
+    connect(m_ui->acNodeTool, &QAction::triggered, [this]() { 
+        this->m_graphDesigner->slotChangeSelectionMode(SelectionMode::NodeEdit); 
+        this->m_inspector->slotChangeInspectorMode(InspectorMode::Node);
+    });
+    connect(m_ui->acEdgeTool, &QAction::triggered, [this]() { 
+        this->m_graphDesigner->slotChangeSelectionMode(SelectionMode::EdgeEdit);
+        this->m_inspector->slotChangeInspectorMode(InspectorMode::Edge);
+    });
     
     connect(inspVisible, SIGNAL(stateChanged(int)), m_graphDesigner->graphView(), SLOT(slotFullInspectorVisible(int)));
     connect(inspVisible, &QCheckBox::stateChanged, [this](int vis) {
@@ -92,8 +101,9 @@ GraphDesignerPage::GraphDesignerPage(MainGUI* mainGUI)
     connect(m_graphDesigner->graphView(), &GraphView::nodeDeselected, [this](const Node& node) {
         this->m_inspector->slotDeselectedNode(node);
     });
-
     connect(m_graphDesigner->graphView(), SIGNAL(clearedSelected()), m_inspector, SLOT(slotClear()));
+
+    connect(m_inspector, SIGNAL(deleteNodes()), m_graphDesigner->graphView(), SLOT(slotDeleteSelectedNodes()));
 
     setCentralWidget(m_graphDesigner);
 

--- a/src/gui/graphdesignerpage.cpp
+++ b/src/gui/graphdesignerpage.cpp
@@ -76,15 +76,12 @@ GraphDesignerPage::GraphDesignerPage(MainGUI* mainGUI)
     
     connect(m_ui->acSelectTool, &QAction::triggered, [this]() { 
         this->m_graphDesigner->slotChangeSelectionMode(SelectionMode::Select); 
-        this->m_inspector->slotChangeInspectorMode(InspectorMode::Select);
     });
     connect(m_ui->acNodeTool, &QAction::triggered, [this]() { 
         this->m_graphDesigner->slotChangeSelectionMode(SelectionMode::NodeEdit); 
-        this->m_inspector->slotChangeInspectorMode(InspectorMode::Node);
     });
     connect(m_ui->acEdgeTool, &QAction::triggered, [this]() { 
         this->m_graphDesigner->slotChangeSelectionMode(SelectionMode::EdgeEdit);
-        this->m_inspector->slotChangeInspectorMode(InspectorMode::Edge);
     });
     
     connect(inspVisible, SIGNAL(stateChanged(int)), m_graphDesigner->graphView(), SLOT(slotFullInspectorVisible(int)));

--- a/src/gui/graphview.cpp
+++ b/src/gui/graphview.cpp
@@ -101,7 +101,7 @@ CacheStatus GraphView::refreshCache()
     return CacheStatus::Ready;
 }
 
-Node GraphView::findNode(const QPointF& pos) const
+Node GraphView::findNode(const QPointF& pos)
 {
     if (m_cacheStatus != CacheStatus::Ready) {
         return Node();

--- a/src/gui/graphview.cpp
+++ b/src/gui/graphview.cpp
@@ -79,17 +79,8 @@ void GraphView::slotUpdateSelection() {
         const Node node = selectedNode.second;
         const QPointF xy = QPointF(node.x() * currEdgeSize(), node.y() * currEdgeSize());
 
-        Star selectedStar(node, xy, {});
-        selectedStar.edges.reserve(node.outEdges().size());
-        for (auto const& ep : node.outEdges()) {
-            QPointF xy2 = nodePoint(ep.second.neighbour(), currEdgeSize());
-            QLineF line(xy, xy2);
-            if (!m_showNodes || line.length() - m_nodeRadius * 2. > 4.0) {
-                selectedStar.edges.push_back({ ep.second, line });
-            }
-        }
-        selectedStar.edges.shrink_to_fit();
-
+        Star selectedStar = createStar(node, currEdgeSize(), xy);
+        
         m_selectedStars.at(i) = selectedStar;
     }
 }

--- a/src/gui/graphview.cpp
+++ b/src/gui/graphview.cpp
@@ -322,31 +322,46 @@ void GraphView::drawSelectedStars(QPainter& painter, double nodeRadius) const
 
     painter.setOpacity(1.0);
 
-    for (auto selectedStar : m_selectedStars) {
+    for (auto selectedNode : m_selectedNodes) {
         // draw shadow of the selected node
+        const Node node = selectedNode.second;
+        const QPointF xy = QPointF(node.x() * currEdgeSize(), node.y() * currEdgeSize());
+
+        Star selectedStar(node, xy, {});
+        selectedStar.edges.reserve(node.outEdges().size());
+        for (auto const& ep : node.outEdges()) {
+            QPointF xy2 = nodePoint(ep.second.neighbour(), currEdgeSize());
+            QLineF line(xy, xy2);
+            if (!m_showNodes || line.length() - m_nodeRadius * 2. > 4.0) {
+                selectedStar.edges.push_back({ep.second, line});
+            }
+        }
+        selectedStar.edges.shrink_to_fit();
+
+
         painter.save();
         double shadowRadius = nodeRadius*1.5;
-        QRadialGradient r(selectedStar.second.xy, shadowRadius, selectedStar.second.xy);
+        QRadialGradient r(selectedStar.xy, shadowRadius, selectedStar.xy);
         r.setColorAt(0, Qt::black);
         r.setColorAt(1, m_background.color());
         painter.setBrush(r);
         painter.setPen(Qt::transparent);
-        painter.drawEllipse(selectedStar.second.xy, shadowRadius, shadowRadius);
+        painter.drawEllipse(selectedStar.xy, shadowRadius, shadowRadius);
         painter.restore();
 
         painter.save();
         // highlight immediate edges
         painter.setPen(QPen(Qt::darkGray, m_edgePen.width() + 3));
-        for (auto const& ep : selectedStar.second.edges) {
+        for (auto const& ep : selectedStar.edges) {
             painter.drawLine(ep.second);
         }
 
         // draw selected node
         painter.setPen(m_nodePen);
-        drawNode(painter, selectedStar.second, nodeRadius);
+        drawNode(painter, selectedStar, nodeRadius);
 
         // draw neighbours
-        const Edges& oe = selectedStar.second.node.outEdges();
+        const Edges& oe = selectedStar.node.outEdges();
         const double esize = currEdgeSize();
         for (auto const& e : oe) {
             const Node& n = e.second.neighbour();

--- a/src/gui/graphview.cpp
+++ b/src/gui/graphview.cpp
@@ -122,7 +122,7 @@ CacheStatus GraphView::refreshCache()
     return CacheStatus::Ready;
 }
 
-Node GraphView::findNode(const QPointF& pos)
+Node GraphView::findNode(const QPointF& pos) const
 {
     if (m_cacheStatus != CacheStatus::Ready) {
         return Node();

--- a/src/gui/graphview.h
+++ b/src/gui/graphview.h
@@ -41,15 +41,15 @@ public slots:
 
 protected:
     void paintFrame(QPainter& painter) const override;
-    Node findNode(const QPointF& pos) override;
-    Node selectNode(const QPointF &pos, bool center) override;
+    Node findNode(const QPointF& pos) const override;
+    Node selectNode(const QPointF& pos, bool center) override;
     bool selectNode(const Node& node, bool center) override;
     bool deselectNode(const Node& node) override;
     inline Node selectedNode() const override;
     inline QPointF selectedNodePos() const override;
     inline void clearSelection() override;
     CacheStatus refreshCache() override;
-    inline bool inSelectedNodes(const Node node) const override;
+    inline bool inSelectedNodes(const Node& node) const override;
     inline QPointF nodePoint(const QPointF& pos) override;
 
 private slots:
@@ -126,7 +126,7 @@ inline QPointF GraphView::nodePoint(const Node& node, const qreal& edgeSizeRate)
 inline QPointF GraphView::nodePoint(const QPointF& pos)
 { return QPointF(pos.x() / currEdgeSize(), pos.y() / currEdgeSize()); }
 
-inline bool GraphView::inSelectedNodes(const Node node) const
+inline bool GraphView::inSelectedNodes(const Node& node) const
 { return m_selectedNodes.count(node.id()) != 0; }
 
 } // evoplex

--- a/src/gui/graphview.h
+++ b/src/gui/graphview.h
@@ -40,7 +40,7 @@ public slots:
 
 protected:
     void paintFrame(QPainter& painter) const override;
-    Node findNode(const QPointF& pos) const override;
+    Node findNode(const QPointF& pos) override;
     Node selectNode(const QPointF &pos, bool center) override;
     bool selectNode(const Node& node, bool center) override;
     bool deselectNode(const Node& node) override;

--- a/src/gui/graphview.h
+++ b/src/gui/graphview.h
@@ -83,6 +83,7 @@ private:
     Star createStar(const Node& node, const qreal& edgeSizeRate, const QPointF& xy);
 
     void drawNode(QPainter& painter, const Star& s, double r) const;
+
     void drawEdges(QPainter& painter) const;
     void drawNodes(QPainter& painter, double nodeRadius) const;
     void drawSelectedEdge(QPainter& painter, double nodeRadius) const;

--- a/src/gui/graphview.h
+++ b/src/gui/graphview.h
@@ -49,7 +49,8 @@ protected:
     inline void clearSelection() override;
     CacheStatus refreshCache() override;
     inline bool inSelectedNodes(const Node node) const override;
-    
+    inline QPointF GraphView::nodePoint(const QPointF& pos) override;
+
 private slots:
     void setEdgeCMap(ColorMap* cmap);
 
@@ -118,6 +119,11 @@ inline qreal GraphView::currEdgeSize() const
 inline QPointF GraphView::nodePoint(const Node& node, const qreal& edgeSizeRate) const
 {
     return QPointF(edgeSizeRate * node.x(), edgeSizeRate * node.y());
+}
+
+inline QPointF GraphView::nodePoint(const QPointF& pos)
+{ 
+    return QPointF(pos.x() / currEdgeSize(), pos.y() / currEdgeSize());
 }
 
 inline bool GraphView::inSelectedNodes(const Node node) const

--- a/src/gui/graphview.h
+++ b/src/gui/graphview.h
@@ -35,6 +35,7 @@ public:
 public slots:
     inline void zoomIn() override;
     inline void zoomOut() override;
+    void slotUpdateSelection() override;
     void setEdgeScale(int v);
     void setEdgeWidth(int v);
 

--- a/src/gui/graphview.h
+++ b/src/gui/graphview.h
@@ -49,7 +49,7 @@ protected:
     inline void clearSelection() override;
     CacheStatus refreshCache() override;
     inline bool inSelectedNodes(const Node node) const override;
-    inline QPointF GraphView::nodePoint(const QPointF& pos) override;
+    inline QPointF nodePoint(const QPointF& pos) override;
 
 private slots:
     void setEdgeCMap(ColorMap* cmap);
@@ -123,9 +123,7 @@ inline QPointF GraphView::nodePoint(const Node& node, const qreal& edgeSizeRate)
 }
 
 inline QPointF GraphView::nodePoint(const QPointF& pos)
-{ 
-    return QPointF(pos.x() / currEdgeSize(), pos.y() / currEdgeSize());
-}
+{ return QPointF(pos.x() / currEdgeSize(), pos.y() / currEdgeSize()); }
 
 inline bool GraphView::inSelectedNodes(const Node node) const
 { return m_selectedNodes.count(node.id()) != 0; }

--- a/src/gui/gridview.cpp
+++ b/src/gui/gridview.cpp
@@ -111,7 +111,7 @@ void GridView::paintFrame(QPainter& painter) const
     }
 }
 
-Node GridView::findNode(const QPointF& pos)
+Node GridView::findNode(const QPointF& pos) const
 {
     if (m_cacheStatus != CacheStatus::Ready) {
         return Node();

--- a/src/gui/gridview.cpp
+++ b/src/gui/gridview.cpp
@@ -100,7 +100,7 @@ void GridView::paintFrame(QPainter& painter) const
     }
 }
 
-Node GridView::findNode(const QPointF& pos) const
+Node GridView::findNode(const QPointF& pos)
 {
     if (m_cacheStatus != CacheStatus::Ready) {
         return Node();

--- a/src/gui/gridview.cpp
+++ b/src/gui/gridview.cpp
@@ -69,6 +69,17 @@ CacheStatus GridView::refreshCache()
     return CacheStatus::Ready;
 }
 
+void GridView::slotUpdateSelection() {
+    for (auto selectedNode : m_selectedNodes) {
+        int i = selectedNode.first;
+        const Node node = selectedNode.second;
+
+        QRectF selectedCellRect = cellRect(node, m_nodeRadius);
+
+        m_selectedCells.at(i).rect = selectedCellRect;
+    }
+}
+
 void GridView::paintFrame(QPainter& painter) const
 {
     if (m_nodeAttr < 0 || !m_nodeCMap) {

--- a/src/gui/gridview.h
+++ b/src/gui/gridview.h
@@ -31,6 +31,9 @@ class GridView : public BaseGraphGL
 public:
     explicit GridView(QWidget* parent);
 
+public slots:
+    void slotUpdateSelection() override;
+
 protected:
     void paintFrame(QPainter& painter) const override;
     Node selectNode(const QPointF& pos, bool center) override;

--- a/src/gui/gridview.h
+++ b/src/gui/gridview.h
@@ -34,7 +34,7 @@ public:
 protected:
     void paintFrame(QPainter& painter) const override;
     Node selectNode(const QPointF& pos, bool center) override;
-    Node findNode(const QPointF& pos) const override;
+    Node findNode(const QPointF& pos) override;
     bool selectNode(const Node& node, bool center) override;
     bool deselectNode(const Node& node) override;
     Node selectedNode() const override;

--- a/src/gui/gridview.h
+++ b/src/gui/gridview.h
@@ -42,6 +42,7 @@ protected:
     void clearSelection() override;
     CacheStatus refreshCache() override;
     inline bool inSelectedNodes(const Node node) const override;
+    inline QPointF nodePoint(const QPointF& pos) override;
 
 private:
     struct Cell {
@@ -76,6 +77,9 @@ inline QRectF GridView::cellRect(const Node& n, double length) const
 
 inline bool GridView::inSelectedNodes(const Node node) const
 { return m_selectedNodes.count(node.id()) != 0; }
+
+inline QPointF GridView::nodePoint(const QPointF& pos)
+{ return QPointF(pos.x() / m_nodeRadius, pos.y() / m_nodeRadius); }
 
 } // evoplex
 #endif // GRIDVIEW_H

--- a/src/gui/gridview.h
+++ b/src/gui/gridview.h
@@ -37,14 +37,14 @@ public slots:
 protected:
     void paintFrame(QPainter& painter) const override;
     Node selectNode(const QPointF& pos, bool center) override;
-    Node findNode(const QPointF& pos) override;
+    Node findNode(const QPointF& pos) const override;
     bool selectNode(const Node& node, bool center) override;
     bool deselectNode(const Node& node) override;
     Node selectedNode() const override;
     inline QPointF selectedNodePos() const override;
     void clearSelection() override;
     CacheStatus refreshCache() override;
-    inline bool inSelectedNodes(const Node node) const override;
+    inline bool inSelectedNodes(const Node& node) const override;
     inline QPointF nodePoint(const QPointF& pos) override;
 
 private:
@@ -78,7 +78,7 @@ inline void GridView::clearSelection() {
 inline QRectF GridView::cellRect(const Node& n, double length) const 
 { return QRectF(n.x() * length, n.y() * length, length, length); }
 
-inline bool GridView::inSelectedNodes(const Node node) const
+inline bool GridView::inSelectedNodes(const Node& node) const
 { return m_selectedNodes.count(node.id()) != 0; }
 
 inline QPointF GridView::nodePoint(const QPointF& pos)


### PR DESCRIPTION
This adds most of the features of node edit mode:

- Right click on a node to remove it
- Left click to add a node (left clicking on a node still opens up the respective inspector)
- Drag any node to move it
- If a selected node is dragged, then every selected node will move along with it